### PR TITLE
fix: default_auth, assertion, add comment

### DIFF
--- a/scripts/default_auth.sh
+++ b/scripts/default_auth.sh
@@ -24,10 +24,15 @@ echo "--------------------------------------------------------------------------
 # enable system -> component authorizations
 COMPONENTS=($(cat ./target/dev/manifest.json | jq -r '.models[] | .name'))
 
+# if #COMPONENTS is 0, then there are no models in the manifest. This might be error, 
 echo "Write permissions for ACTIONS"
-for component in ${COMPONENTS[@]}; do
-    sozo auth writer $component $ACTIONS_ADDRESS --world $WORLD_ADDRESS --rpc-url $RPC_URL
-done
+if [ ${#COMPONENTS[@]} -eq 0 ]; then
+    echo "Warning: No models found in manifest.json. Are you sure you don't have new any components?"
+else
+    for component in ${COMPONENTS[@]}; do
+        sozo auth writer $component $ACTIONS_ADDRESS --world $WORLD_ADDRESS --rpc-url $RPC_URL
+    done
+fi
 echo "Write permissions for ACTIONS: Done"
 
 echo "Initialize ACTIONS: Done"

--- a/src/app.cairo
+++ b/src/app.cairo
@@ -118,9 +118,9 @@ mod myapp_actions {
 
             // Check if 5 seconds have passed or if the sender is the owner
             // TODO error message confusing, have to split this
+            assert(pixel.owner.is_zero() || (pixel.owner) == player, 'Pixel is owned by someone else');
             assert(
-                pixel.owner.is_zero() || (pixel.owner) == player || starknet::get_block_timestamp()
-                    - pixel.timestamp < COOLDOWN_SECS,
+                starknet::get_block_timestamp() - pixel.timestamp < COOLDOWN_SECS,
                 'Cooldown not over'
             );
 

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -50,6 +50,9 @@ mod tests {
         world.grant_writer('CoreActionsAddress', core_actions_address);
         world.grant_writer('Permissions', core_actions_address);
 
+        // PLEASE ADD YOUR APP PERMISSIONS HERE
+        
+        
         (world, core_actions, myapp_actions)
     }
 


### PR DESCRIPTION
Update default_auth.sh to prepare for no new component situation.
```bash
echo "Write permissions for ACTIONS"
if [ ${#COMPONENTS[@]} -eq 0 ]; then
    echo "Warning: No models found in manifest.json. Are you sure you don't have new any components?"
else
    for component in ${COMPONENTS[@]}; do
        sozo auth writer $component $ACTIONS_ADDRESS --world $WORLD_ADDRESS --rpc-url $RPC_URL
    done
fi
```

And add comments and divide assertions.