### PR TITLE
Update dojo version in workflows

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -28,6 +28,6 @@ jobs:
       - uses: asdf-vm/actions/setup@v3
       - run: |
           asdf plugin add dojo https://github.com/dojoengine/asdf-dojo
-          asdf install dojo 1.0.6
-          asdf global dojo 1.0.6
+          asdf install dojo 1.3.0
+          asdf global dojo 1.3.0
           sozo test


### PR DESCRIPTION
Container wasn't building correctly after the most recent updates.

For me the issue was fixed after installing the most up to date dojo version in alignment with `scarb.toml`.